### PR TITLE
WINDUP-3726 Refactored 'intersectTechnologies' method

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,30 @@
+on:
+    pull_request_target:
+        types: ["labeled", "closed"]
+
+jobs:
+    backport:
+        name: Backport PR
+        runs-on: ubuntu-latest
+        if: |
+            github.event.pull_request.merged == true
+            && contains(github.event.pull_request.labels.*.name, 'auto-backport')
+            && (
+              (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
+              || (github.event.action == 'closed')
+            )
+        steps:
+            - name: Backport Action
+              uses: sqren/backport-github-action@v8
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  auto_backport_label_prefix: auto-backport-to-
+                  add_original_reviewers: true
+    
+            - name: Info log
+              if: ${{ success() }}
+              run: cat ~/.backport/backport.info.log
+    
+            - name: Debug log
+              if: ${{ failure() }}
+              run: cat ~/.backport/backport.debug.log

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
             )
         steps:
             - name: Backport Action
-              uses: sqren/backport-github-action@v8
+              uses: sqren/backport-github-action@v8.9.7
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   auto_backport_label_prefix: auto-backport-to-

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
     <properties>
         <version.forge>3.10.0.Final</version.forge>
         <version.furnace>2.29.1.Final</version.furnace>
-        <version.nexus.index>23.03.15.Final</version.nexus.index>
+        <version.nexus.index>23.03.23.Final</version.nexus.index>
         <version.lucene>7.1.0</version.lucene>
         <version.groovy>2.4.21</version.groovy>
         <version.freemarker>2.3.31</version.freemarker>

--- a/reporting/api/src/main/java/org/jboss/windup/reporting/config/TechnologiesIntersector.java
+++ b/reporting/api/src/main/java/org/jboss/windup/reporting/config/TechnologiesIntersector.java
@@ -31,16 +31,10 @@ public class TechnologiesIntersector {
     private static List<TechnologyReferenceModel> intersectTechnologies(Collection<TechnologyReferenceModel> configuredTechnologies, Collection<TechnologyReference> ruleTechnologies) {
         return configuredTechnologies.stream()
                 .filter(confTech -> {
-                    Set<TechnologyReference> confTechsWithSameId = ruleTechnologies.stream().filter(ruleTech -> confTech.getTechnologyID().equals(ruleTech.getId())).collect(toSet());
-                    return !confTechsWithSameId.isEmpty();
-                })
-                .filter(confTech -> ruleTechnologies.stream().filter(ruleTech -> {
-                    if (ruleTech.getId().equals(confTech.getTechnologyID())) {
-                        TechnologyReference confTechRef = new TechnologyReference(confTech);
-                        return !confTechRef.versionRangesOverlap(ruleTech.getVersionRange());
-                    }
-                    return false;
-                }).collect(toSet()).isEmpty())
+                            final TechnologyReference confTechRef = new TechnologyReference(confTech);
+                            return ruleTechnologies.stream().anyMatch(confTechRef::matches);
+                        }
+                )
                 .collect(toList());
     }
 }


### PR DESCRIPTION
I've tried to refactor `intersectTechnologies` method the based on:

- [confTech.getTechnologyID().equals(ruleTech.getId())](https://github.com/windup/windup/pull/1624/files#diff-c3166ab603bd51de0e2ca8370d7310c35db7d0d703729b6e7b56e1a74c482a33R34) looks redundant with following [ruleTech.getId().equals(confTech.getTechnologyID())](https://github.com/windup/windup/pull/1624/files#diff-c3166ab603bd51de0e2ca8370d7310c35db7d0d703729b6e7b56e1a74c482a33R34) so I've removed the first `filter`
- evaluate `anyMatch` rather than `collect(toSet()).isEmpty()`
- leveraging the `TechnologyReference.matches` method for testing `TechnologyReference` references